### PR TITLE
fix: trully set maximum when clicking on "Set Max"

### DIFF
--- a/src/components/DepositForm.js
+++ b/src/components/DepositForm.js
@@ -78,7 +78,7 @@ export const DepositForm = () => {
                     onClick={() =>
                       setFieldValue(
                         "amount",
-                        (+currentUser.ethBalance).toPrecision(4)
+                        currentUser.ethBalance
                       )
                     }
                   >

--- a/src/components/WithdrawForm.js
+++ b/src/components/WithdrawForm.js
@@ -78,7 +78,7 @@ export const WithdrawForm = () => {
                     onClick={() =>
                       setFieldValue(
                         "amount",
-                        (+currentUser.wethBalance).toPrecision(4)
+                        currentUser.wethBalance
                       )
                     }
                   >


### PR DESCRIPTION
Both WETH and WXDAI have 18 decimals, but Numbers can't be stored with that much precision (because `Number.EPSILON` is equal to `2.220446049250313e-16`), hence when clicking on "Set Max", the amount will be set as a `string`

I've tested it and using a string works when calling the contract method using Metamak. Meanwhile the number input type continue to work (ei: increment/decrement)

fixes #9 