### PR TITLE
Adds Stories showing both logged-in and logged-out views of components

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto eol=lf
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_STORE
 node_modules
 .env
+yarn-error.log

--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,6 @@
   "jsxSingleQuote": true,
   "semi": true,
   "trailingComma": "all",
-  "tabWidth": 2
+  "tabWidth": 2,
+  "endOfLine": "auto"
 }

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -2,7 +2,7 @@ module.exports = {
   stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
   addons: [
     '@storybook/addon-links',
-    '@storybook/addon-essentials',
+    // '@storybook/addon-essentials',
     '@storybook/preset-create-react-app',
   ],
   webpackFinal: async (config) => {
@@ -13,7 +13,7 @@ module.exports = {
         alias: {
           ...config.resolve.alias,
           '@emotion/core': '@emotion/react',
-          'emotion-theming': '@emotion/react'
+          'emotion-theming': '@emotion/react',
         },
       },
     };

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,11 +1,37 @@
+const path = require('path');
+
 module.exports = {
   stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
   addons: [
+    '@storybook/addon-docs',
     '@storybook/addon-links',
-    // '@storybook/addon-essentials',
+    '@storybook/addon-essentials',
     '@storybook/preset-create-react-app',
+    'storybook-addon-react-docgen',
   ],
   webpackFinal: async (config) => {
+    config.module.rules.push({
+      test: /\.(ts|tsx)$/,
+      use: [
+        {
+          loader: require.resolve('ts-loader'),
+          options: {
+            transpileOnly: true,
+          },
+        },
+        {
+          loader: require.resolve('react-docgen-typescript-loader'),
+          options: {
+            // Provide the path to your tsconfig.json so that your stories can
+            // display types from outside each individual story.
+            tsconfigPath: path.resolve(__dirname, '../tsconfig.json'),
+          },
+        },
+      ],
+    });
+
+    config.resolve.extensions.push('.ts', '.tsx');
+
     return {
       ...config,
       resolve: {

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -13,7 +13,7 @@ module.exports = {
         alias: {
           ...config.resolve.alias,
           '@emotion/core': '@emotion/react',
-          'emotion-theming': '@emotion/react',
+          'emotion-theming': '@emotion/react'
         },
       },
     };

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,5 +1,6 @@
 import { addDecorator } from '@storybook/react';
 import { ChakraProvider, CSSReset } from '@chakra-ui/react';
+import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 import React from 'react';
 
 import { theme } from '../src/theme';
@@ -17,6 +18,9 @@ addDecorator((StoryFn) => (
 ));
 
 export const parameters = {
+  viewport: {
+    viewports: INITIAL_VIEWPORTS,
+  },
   actions: { argTypesRegex: '^on[A-Z].*' },
   controls: {
     matchers: {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # WrapETH
 
 ## Use the app
+
 [https://wrapeth.com](https://wrapeth.com)
 
 Built by [Raid Guild](https://raidguild.org)

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   },
   "devDependencies": {
     "@storybook/addon-actions": "^6.2.9",
+    "@storybook/addon-docs": "^6.2.9",
     "@storybook/addon-essentials": "^6.2.9",
     "@storybook/addon-links": "^6.2.9",
     "@storybook/node-logger": "^6.2.9",
@@ -101,6 +102,9 @@
     "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-standard": "^5.0.0",
     "prettier": "^2.2.1",
-    "typescript": "^4.2.4"
+    "react-docgen-typescript-loader": "3.7.2",
+    "storybook-addon-react-docgen": "1.2.42",
+    "ts-loader": "8.2.0",
+    "typescript": "4.2.2"
   }
 }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,7 +3,7 @@
   "name": "WrapEth",
   "description": "No fees, no frills ETH wrapper",
   "iconPath": "logo192.png",
-  "providedBy": {"name": "Raid Guild", "url": "https://raidguild.org"},
+  "providedBy": { "name": "Raid Guild", "url": "https://raidguild.org" },
   "icons": [
     {
       "src": "favicon.ico",

--- a/src/components/AppContainer/appContainer.stories.tsx
+++ b/src/components/AppContainer/appContainer.stories.tsx
@@ -18,6 +18,16 @@ const mockGetter = () => {
   }
 };
 
+export const loggedOutDecorator = (StoryInst: Story) => {
+  setTestUseCurrentUser(mockGetter, true);
+  return <StoryInst />;
+};
+
+export const loggedInDecorator = (StoryInst: Story) => {
+  setTestUseCurrentUser(mockGetter, false);
+  return <StoryInst />;
+};
+
 export default {
   title: 'Components/App/AppContainer',
   component: AppContainer,
@@ -32,21 +42,11 @@ WalletConnected.args = {
   // backgroundColor: 'white',
 };
 
-WalletConnected.decorators = [
-  (Story) => {
-    setTestUseCurrentUser(mockGetter);
-    return <Story />
-  }
-]
+WalletConnected.decorators = [loggedInDecorator,];
 
 export const WalledDisconnected = Template.bind({});
 WalledDisconnected.args = {
   // backgroundColor: 'black',
 };
 
-WalledDisconnected.decorators = [
-  (Story) => {
-    setTestUseCurrentUser(mockGetter, true);
-    return <Story />
-  }
-]
+WalledDisconnected.decorators = [loggedOutDecorator,];

--- a/src/components/AppContainer/appContainer.stories.tsx
+++ b/src/components/AppContainer/appContainer.stories.tsx
@@ -1,21 +1,55 @@
-import React from 'react';
+/* eslint-disable prettier/prettier */
+import React, { useEffect } from 'react';
 import { Story, Meta } from '@storybook/react';
-
 import { AppContainer, AppContainerProps } from '.';
+import { setTestUseCurrentUser } from '../../contexts/currentUserContext';
+
+const mockGetter = () => {
+  console.log('mock Getter') //eslint-disable-line
+  return {
+    currentUser: {
+      type: 'web3',
+      attributes: { 'custom:account_address': '111' },
+      network: { chain: 'demoETH' },
+      username: 'Demo',
+      ethBalance: 1.1,
+      wethBalance: 2.2,
+    },
+    setCurrentUser: () => {},
+  }
+};
 
 export default {
   title: 'Components/App/AppContainer',
   component: AppContainer,
 } as Meta;
 
+const ControlledTemplate: Story<AppContainerProps> = (args) => <AppContainer {...args} />;
+
 const Template: Story<AppContainerProps> = (args) => <AppContainer {...args} />;
 
-export const Light = Template.bind({});
+export const Light = ControlledTemplate.bind({});
 Light.args = {
   // backgroundColor: 'white',
 };
+
+Light.decorators = [
+  (Story) => {
+    console.log('effect light'); //eslint-disable-line
+    setTestUseCurrentUser(mockGetter);
+    return <Story />
+  }
+]
 
 export const Dark = Template.bind({});
 Dark.args = {
   // backgroundColor: 'black',
 };
+
+Dark.decorators = [
+  (Story) => {
+    console.log('effect dark'); //eslint-disable-line
+    setTestUseCurrentUser(mockGetter, true);
+    return <Story />
+  }
+]

--- a/src/components/AppContainer/appContainer.stories.tsx
+++ b/src/components/AppContainer/appContainer.stories.tsx
@@ -1,17 +1,16 @@
 /* eslint-disable prettier/prettier */
-import React, { useEffect } from 'react';
+import React from 'react';
 import { Story, Meta } from '@storybook/react';
 import { AppContainer, AppContainerProps } from '.';
 import { setTestUseCurrentUser } from '../../contexts/currentUserContext';
 
 const mockGetter = () => {
-  console.log('mock Getter') //eslint-disable-line
   return {
     currentUser: {
       type: 'web3',
       attributes: { 'custom:account_address': '111' },
       network: { chain: 'demoETH' },
-      username: 'Demo',
+      username: '0x1234567',
       ethBalance: 1.1,
       wethBalance: 2.2,
     },
@@ -28,27 +27,25 @@ const ControlledTemplate: Story<AppContainerProps> = (args) => <AppContainer {..
 
 const Template: Story<AppContainerProps> = (args) => <AppContainer {...args} />;
 
-export const Light = ControlledTemplate.bind({});
-Light.args = {
+export const WalletConnected = ControlledTemplate.bind({});
+WalletConnected.args = {
   // backgroundColor: 'white',
 };
 
-Light.decorators = [
+WalletConnected.decorators = [
   (Story) => {
-    console.log('effect light'); //eslint-disable-line
     setTestUseCurrentUser(mockGetter);
     return <Story />
   }
 ]
 
-export const Dark = Template.bind({});
-Dark.args = {
+export const WalledDisconnected = Template.bind({});
+WalledDisconnected.args = {
   // backgroundColor: 'black',
 };
 
-Dark.decorators = [
+WalledDisconnected.decorators = [
   (Story) => {
-    console.log('effect dark'); //eslint-disable-line
     setTestUseCurrentUser(mockGetter, true);
     return <Story />
   }

--- a/src/components/AppContainer/appContainer.stories.tsx
+++ b/src/components/AppContainer/appContainer.stories.tsx
@@ -2,38 +2,16 @@
 import React from 'react';
 import { Story, Meta } from '@storybook/react';
 import { AppContainer, AppContainerProps } from '.';
-import { setTestUseCurrentUser } from '../../contexts/currentUserContext';
-
-const mockGetter = () => {
-  return {
-    currentUser: {
-      type: 'web3',
-      attributes: { 'custom:account_address': '111' },
-      network: { chain: 'demoETH' },
-      username: '0x1234567',
-      ethBalance: 1.1,
-      wethBalance: 2.2,
-    },
-    setCurrentUser: () => {},
-  }
-};
-
-export const loggedOutDecorator = (StoryInst: Story) => {
-  setTestUseCurrentUser(mockGetter, true);
-  return <StoryInst />;
-};
-
-export const loggedInDecorator = (StoryInst: Story) => {
-  setTestUseCurrentUser(mockGetter, false);
-  return <StoryInst />;
-};
+import { loggedOutDecorator, loggedInDecorator } from '../storyHelper';
 
 export default {
   title: 'Components/App/AppContainer',
   component: AppContainer,
 } as Meta;
 
-const ControlledTemplate: Story<AppContainerProps> = (args) => <AppContainer {...args} />;
+const ControlledTemplate: Story<AppContainerProps> = (args) => (
+  <AppContainer {...args} />
+);
 
 const Template: Story<AppContainerProps> = (args) => <AppContainer {...args} />;
 
@@ -42,11 +20,11 @@ WalletConnected.args = {
   // backgroundColor: 'white',
 };
 
-WalletConnected.decorators = [loggedInDecorator,];
+WalletConnected.decorators = [loggedInDecorator];
 
 export const WalledDisconnected = Template.bind({});
 WalledDisconnected.args = {
   // backgroundColor: 'black',
 };
 
-WalledDisconnected.decorators = [loggedOutDecorator,];
+WalledDisconnected.decorators = [loggedOutDecorator];

--- a/src/components/AppContainer/index.tsx
+++ b/src/components/AppContainer/index.tsx
@@ -28,7 +28,7 @@ export interface AppContainerProps {
  */
 export const AppContainer: React.FC<AppContainerProps> = ({ children }) => {
   const { currentUser } = useCurrentUser();
-
+  console.log('current user', currentUser); //eslint-disable-line
   const [deposit, setDeposit] = useState<boolean>(true);
 
   const onButtonSelection = (index: number) => {

--- a/src/components/AppContainer/index.tsx
+++ b/src/components/AppContainer/index.tsx
@@ -28,7 +28,6 @@ export interface AppContainerProps {
  */
 export const AppContainer: React.FC<AppContainerProps> = ({ children }) => {
   const { currentUser } = useCurrentUser();
-  console.log('current user', currentUser); //eslint-disable-line
   const [deposit, setDeposit] = useState<boolean>(true);
 
   const onButtonSelection = (index: number) => {

--- a/src/components/AppContainer/index.tsx
+++ b/src/components/AppContainer/index.tsx
@@ -15,6 +15,7 @@ import logo from '../../assets/wrapeth_logo.png';
 import { useCurrentUser } from '../../contexts/currentUserContext';
 import { DepositForm } from '../molecules/DepositForm';
 import { WithdrawForm } from '../molecules/WithdrawForm';
+import { Card } from '../atoms/Card';
 
 export interface AppContainerProps {
   /**
@@ -49,7 +50,11 @@ export const AppContainer: React.FC<AppContainerProps> = ({ children }) => {
       : '';
 
   return (
-    <Flex h='100vh' w='100vw'>
+    <Flex
+      minHeight='100vh'
+      minWidth='100vw'
+      bg='linear-gradient(157.1deg, #22002b 0%, #390418 29.17%, #48093A 61.98%, #1F0442 100%)'
+    >
       <SidePanel>
         <Image src={raidGuildLogoLeft} alt='Swords logo' maxH='75vh' />
       </SidePanel>
@@ -66,23 +71,25 @@ export const AppContainer: React.FC<AppContainerProps> = ({ children }) => {
           <AccountButton />
         </Header>
         <Container centerContent marginTop='10px'>
-          <ButtonGroup
-            buttons={[`Wrap ${networkName}`, `Unwrap w${networkName}`]}
-            defaultSelected={deposit ? 0 : 1}
-            isAttached
-            onSelect={onButtonSelection}
-          />
-          {deposit ? (
-            currentUser?.username ? (
-              <DepositForm />
+          <Card>
+            <ButtonGroup
+              buttons={[`Wrap ${networkName}`, `Unwrap w${networkName}`]}
+              defaultSelected={deposit ? 0 : 1}
+              isAttached
+              onSelect={onButtonSelection}
+            />
+            {deposit ? (
+              currentUser?.username ? (
+                <DepositForm />
+              ) : (
+                <Text bg='transparent'>Connect to Wrap {networkName}</Text>
+              )
+            ) : currentUser?.username ? (
+              <WithdrawForm />
             ) : (
-              <Text>Connect to Wrap {networkName}</Text>
-            )
-          ) : currentUser?.username ? (
-            <WithdrawForm />
-          ) : (
-            <Text>Connect to Unwrap w{networkName}</Text>
-          )}
+              <Text bg='transparent'>Connect to Unwrap w{networkName}</Text>
+            )}
+          </Card>
         </Container>
 
         <Spacer />

--- a/src/components/atoms/Card/Card.stories.tsx
+++ b/src/components/atoms/Card/Card.stories.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import { Card, CardProps } from '.';
+import { Heading } from '@chakra-ui/react';
+
+export default {
+  title: 'Components/Atoms/Card',
+  component: Card,
+} as Meta;
+
+const Template: Story<CardProps> = (args) => <Card {...args} />;
+
+export const WithHeading = Template.bind({});
+WithHeading.args = {
+  children: (
+    <Heading
+      variant='texturina'
+      textTransform='uppercase'
+      fontSize={{ base: '16px' }}
+      mb={5}
+      textAlign='center'
+    >
+      Card Title
+    </Heading>
+  ),
+};
+
+export const Empty = Template.bind({});
+Empty.args = {};

--- a/src/components/atoms/Card/index.tsx
+++ b/src/components/atoms/Card/index.tsx
@@ -1,0 +1,22 @@
+import { Flex } from '@chakra-ui/react';
+import React from 'react';
+
+export interface CardProps {
+  children?: {};
+}
+
+export const Card: React.FC<CardProps> = ({ children }) => (
+  <Flex
+    width='100%'
+    direction='column'
+    alignItems='center'
+    justifyContent='space-evenly'
+    py='2rem'
+    px='1.5rem'
+    bg='black'
+    borderTop='2px solid'
+    borderColor='red'
+  >
+    {children}
+  </Flex>
+);

--- a/src/components/atoms/Header/Header.stories.tsx
+++ b/src/components/atoms/Header/Header.stories.tsx
@@ -1,7 +1,7 @@
 import React, { Fragment } from 'react';
 import { Story, Meta } from '@storybook/react';
 
-import { Image, Spacer } from '@chakra-ui/react';
+import { Image, Spacer, Container } from '@chakra-ui/react';
 
 import { Header, HeaderProps } from '.';
 import { AccountButton } from '../../molecules/AccountButton';
@@ -13,7 +13,13 @@ export default {
   component: Header,
 } as Meta;
 
-const Template: Story<HeaderProps> = (args) => <Header {...args} />;
+const Template: Story<HeaderProps> = (args) => {
+  return (
+    <Container centerContent flexDirection='column' width='100%'>
+      <Header {...args} />
+    </Container>
+  );
+};
 
 export const WithButton = Template.bind({});
 WithButton.args = {

--- a/src/components/atoms/SidePanel/SidePanel.stories.tsx
+++ b/src/components/atoms/SidePanel/SidePanel.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
+import { Image, Flex, Spacer } from '@chakra-ui/react';
 import { Story, Meta } from '@storybook/react';
-import { ArgsTable } from '@storybook/addon-docs/blocks';
-
+import logo from '../../../assets/wrapeth_logo.png';
 import { SidePanel, SidePanelProps } from '.';
 
 export default {
@@ -16,12 +16,22 @@ const Template: Story<SidePanelProps> = (args) => <SidePanel {...args} />;
 
 export const WithLogoLeft = Template.bind({});
 WithLogoLeft.args = {
-  // position: 'left',
+  children: (
+    <Flex>
+      <Image src={logo} alt='wrapeth logo' max-width='240px' height='auto' />
+      <Spacer />
+    </Flex>
+  ),
 };
 
 export const WithLogoRight = Template.bind({});
 WithLogoRight.args = {
-  // position: 'right',
+  children: (
+    <Flex>
+      <Spacer />
+      <Image src={logo} alt='wrapeth logo' max-width='240px' height='auto' />
+    </Flex>
+  ),
 };
 
 export const Empty = Template.bind({});

--- a/src/components/atoms/Text/index.tsx
+++ b/src/components/atoms/Text/index.tsx
@@ -31,7 +31,13 @@ export const Text: React.FC<TextProps> = ({
   ...props
 }) => {
   return (
-    <CText fontSize={size} isTruncated={truncated} color={color} {...props}>
+    <CText
+      bg='transparent'
+      fontSize={size}
+      isTruncated={truncated}
+      color={color}
+      {...props}
+    >
       {content}
     </CText>
   );

--- a/src/components/molecules/AccountButton/AccountButton.stories.tsx
+++ b/src/components/molecules/AccountButton/AccountButton.stories.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { Story, Meta } from '@storybook/react';
-import { ArgsTable } from '@storybook/addon-docs/blocks';
+import {
+  loggedOutDecorator,
+  loggedInDecorator,
+} from '../../AppContainer/appContainer.stories';
 
 import { AccountButton, AccountButtonProps } from '.';
 
@@ -13,17 +16,10 @@ const Template: Story<AccountButtonProps> = (args) => (
   <AccountButton {...args} />
 );
 
-// const mockUser: User = {
-//   type: 'web3',
-//   attributes: {
-//     'custom:account_address': '0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B',
-//   },
-//   network: '1010101010',
-//   username: '0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B',
-// };
-
 export const LoggedOut = Template.bind({});
 LoggedOut.args = {};
+LoggedOut.decorators = [loggedOutDecorator];
 
 export const LoggedIn = Template.bind({});
 LoggedIn.args = {};
+LoggedIn.decorators = [loggedInDecorator];

--- a/src/components/molecules/AccountButton/AccountButton.stories.tsx
+++ b/src/components/molecules/AccountButton/AccountButton.stories.tsx
@@ -1,9 +1,6 @@
 import React from 'react';
 import { Story, Meta } from '@storybook/react';
-import {
-  loggedOutDecorator,
-  loggedInDecorator,
-} from '../../AppContainer/appContainer.stories';
+import { loggedOutDecorator, loggedInDecorator } from '../../storyHelper';
 
 import { AccountButton, AccountButtonProps } from '.';
 

--- a/src/components/molecules/AccountButton/index.tsx
+++ b/src/components/molecules/AccountButton/index.tsx
@@ -26,7 +26,8 @@ export const AccountButton: React.FC<AccountButtonProps> = ({ children }) => {
   return currentUser?.username ? (
     <Button
       textStyle='buttonLabel'
-      maxW='120px'
+      maxW='100%'
+      width='auto'
       variant={'outline'}
       onClick={() => disconnectDapp()}
     >
@@ -35,7 +36,13 @@ export const AccountButton: React.FC<AccountButtonProps> = ({ children }) => {
         onClick={() => disconnectDapp()}
         pr='5px'
       />
-      <Text overflow='hidden' textOverflow='ellipsis' isTruncated color='white'>
+      <Text
+        bg='transparent'
+        overflow='hidden'
+        textOverflow='ellipsis'
+        isTruncated
+        color='white'
+      >
         {currentUser.username}
       </Text>
     </Button>

--- a/src/components/molecules/ButtonGroup/index.tsx
+++ b/src/components/molecules/ButtonGroup/index.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 
 import { Button, ButtonGroup as CButtonGroup } from '@chakra-ui/button';
+import { Flex } from '@chakra-ui/react';
 
 export interface ButtonGroupProps {
   /**
@@ -32,7 +33,7 @@ export interface ButtonGroupProps {
 export const ButtonGroup: React.FC<ButtonGroupProps> = ({
   buttons,
   defaultSelected = 0,
-  size = 'md',
+  size = 'sm',
   isAttached = true,
   onSelect,
   ...props
@@ -51,6 +52,7 @@ export const ButtonGroup: React.FC<ButtonGroupProps> = ({
           <Button
             key={i}
             variant={i === selected ? 'solid' : 'outline'}
+            color='white'
             size={size}
             onClick={() => handleSelection(i)}
             {...props}

--- a/src/components/molecules/DepositForm/DepositForm.stories.tsx
+++ b/src/components/molecules/DepositForm/DepositForm.stories.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { Story, Meta } from '@storybook/react';
-import { ArgsTable } from '@storybook/addon-docs/blocks';
+import {
+  loggedOutDecorator,
+  loggedInDecorator,
+} from '../../AppContainer/appContainer.stories';
+import { setTestUseCurrentUser } from '../../../contexts/currentUserContext';
 
 import { DepositForm, DepositFormProps } from '.';
 
@@ -11,17 +15,10 @@ export default {
 
 const Template: Story<DepositFormProps> = (args) => <DepositForm {...args} />;
 
-// const mockUser: User = {
-//   type: 'web3',
-//   attributes: {
-//     'custom:account_address': '0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B',
-//   },
-//   network: '1010101010',
-//   username: '0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B',
-// };
-
 export const LoggedOut = Template.bind({});
 LoggedOut.args = {};
+LoggedOut.decorators = [loggedOutDecorator];
 
 export const LoggedIn = Template.bind({});
 LoggedIn.args = {};
+LoggedIn.decorators = [loggedInDecorator];

--- a/src/components/molecules/DepositForm/DepositForm.stories.tsx
+++ b/src/components/molecules/DepositForm/DepositForm.stories.tsx
@@ -1,11 +1,6 @@
 import React from 'react';
 import { Story, Meta } from '@storybook/react';
-import {
-  loggedOutDecorator,
-  loggedInDecorator,
-} from '../../AppContainer/appContainer.stories';
-import { setTestUseCurrentUser } from '../../../contexts/currentUserContext';
-
+import { loggedOutDecorator, loggedInDecorator } from '../../storyHelper';
 import { DepositForm, DepositFormProps } from '.';
 
 export default {

--- a/src/components/molecules/DepositForm/index.tsx
+++ b/src/components/molecules/DepositForm/index.tsx
@@ -13,12 +13,11 @@ import {
   NumberInputStepper,
   NumberIncrementStepper,
   NumberDecrementStepper,
-  HStack,
-  Spacer,
   FormLabel,
   Container,
   InputGroup,
   InputRightAddon,
+  Flex,
 } from '@chakra-ui/react';
 import { User } from '../../../types';
 import { TokenInfo } from '../TokenInfo';
@@ -94,19 +93,22 @@ export const DepositForm: React.FC<DepositFormProps> = () => {
         }) => (
           <Form>
             <FormControl id='depositForm' isRequired>
-              <HStack>
+              <Flex
+                marginTop='5px'
+                alignItems='center'
+                justifyContent='space-between'
+                flexWrap='wrap'
+              >
                 <FormLabel>{currentUser?.network?.chain}</FormLabel>
-                <Spacer />
                 <TokenInfo deposit />
-              </HStack>
-              <InputGroup marginBottom='5px'>
+              </Flex>
+              <InputGroup size='md' marginBottom='16px'>
                 <NumberInput
                   value={values.amount}
                   textColor='white'
                   placeholder='Amount to wrap'
                   precision={4}
                   variant='outline'
-                  width='80%'
                   onChange={(e) => {
                     console.log(e);
                     setFieldValue('amount', e);
@@ -124,10 +126,8 @@ export const DepositForm: React.FC<DepositFormProps> = () => {
                 <InputRightAddon m={0} p={0}>
                   <Button
                     variant='solid'
-                    size='lg'
-                    h='100%'
-                    w='100%'
                     borderLeftRadius='none'
+                    size='lg'
                     onClick={() => {
                       if (currentUser?.ethBalance) {
                         setFieldValue(

--- a/src/components/molecules/TokenInfo/TokenInfo.stories.tsx
+++ b/src/components/molecules/TokenInfo/TokenInfo.stories.tsx
@@ -1,9 +1,6 @@
 import React from 'react';
 import { Story, Meta } from '@storybook/react';
-import {
-  loggedOutDecorator,
-  loggedInDecorator,
-} from '../../AppContainer/appContainer.stories';
+import { loggedOutDecorator, loggedInDecorator } from '../../storyHelper';
 import { TokenInfo, TokenInfoProps } from '.';
 
 export default {

--- a/src/components/molecules/TokenInfo/TokenInfo.stories.tsx
+++ b/src/components/molecules/TokenInfo/TokenInfo.stories.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { Story, Meta } from '@storybook/react';
-import { ArgsTable } from '@storybook/addon-docs/blocks';
-
+import {
+  loggedOutDecorator,
+  loggedInDecorator,
+} from '../../AppContainer/appContainer.stories';
 import { TokenInfo, TokenInfoProps } from '.';
 
 export default {
@@ -11,17 +13,10 @@ export default {
 
 const Template: Story<TokenInfoProps> = (args) => <TokenInfo {...args} />;
 
-// const mockUser: User = {
-//   type: 'web3',
-//   attributes: {
-//     'custom:account_address': '0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B',
-//   },
-//   network: '1010101010',
-//   username: '0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B',
-// };
-
 export const Fetching = Template.bind({});
 Fetching.args = {};
+Fetching.decorators = [loggedOutDecorator];
 
 export const LoggedIn = Template.bind({});
 LoggedIn.args = {};
+LoggedIn.decorators = [loggedInDecorator];

--- a/src/components/molecules/WithdrawForm/WithdrawForm.stories.tsx
+++ b/src/components/molecules/WithdrawForm/WithdrawForm.stories.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { Story, Meta } from '@storybook/react';
-import { ArgsTable } from '@storybook/addon-docs/blocks';
-
+import {
+  loggedOutDecorator,
+  loggedInDecorator,
+} from '../../AppContainer/appContainer.stories';
 import { WithdrawForm, WithdrawFormProps } from '.';
 
 export default {
@@ -22,6 +24,8 @@ const Template: Story<WithdrawFormProps> = (args) => <WithdrawForm {...args} />;
 
 export const LoggedOut = Template.bind({});
 LoggedOut.args = {};
+LoggedOut.decorators = [loggedOutDecorator];
 
 export const LoggedIn = Template.bind({});
 LoggedIn.args = {};
+LoggedIn.decorators = [loggedInDecorator];

--- a/src/components/molecules/WithdrawForm/WithdrawForm.stories.tsx
+++ b/src/components/molecules/WithdrawForm/WithdrawForm.stories.tsx
@@ -1,9 +1,6 @@
 import React from 'react';
 import { Story, Meta } from '@storybook/react';
-import {
-  loggedOutDecorator,
-  loggedInDecorator,
-} from '../../AppContainer/appContainer.stories';
+import { loggedOutDecorator, loggedInDecorator } from '../../storyHelper';
 import { WithdrawForm, WithdrawFormProps } from '.';
 
 export default {

--- a/src/components/molecules/WithdrawForm/index.tsx
+++ b/src/components/molecules/WithdrawForm/index.tsx
@@ -13,12 +13,11 @@ import {
   NumberInputStepper,
   NumberIncrementStepper,
   NumberDecrementStepper,
-  HStack,
-  Spacer,
   FormLabel,
   Container,
   InputGroup,
   InputRightAddon,
+  Flex,
 } from '@chakra-ui/react';
 import { User } from '../../../types';
 import { TokenInfo } from '../TokenInfo';
@@ -96,18 +95,21 @@ export const WithdrawForm: React.FC<WithdrawFormProps> = () => {
         }) => (
           <Form>
             <FormControl id='withdrawForm' isRequired>
-              <HStack>
+              <Flex
+                marginTop='5px'
+                alignItems='center'
+                justifyContent='space-between'
+                flexWrap='wrap'
+              >
                 <FormLabel>{currentUser?.network?.chain}</FormLabel>
-                <Spacer />
                 <TokenInfo deposit={false} />
-              </HStack>
-              <InputGroup marginBottom='5px'>
+              </Flex>
+              <InputGroup size='md' marginBottom='16px'>
                 <NumberInput
                   value={values.amount}
                   placeholder='Amount to unwrap'
                   precision={4}
                   variant='outline'
-                  width='80%'
                   onChange={(e) => setFieldValue('amount', e)}
                   onBlur={handleBlur}
                   min={0}
@@ -122,10 +124,8 @@ export const WithdrawForm: React.FC<WithdrawFormProps> = () => {
                 <InputRightAddon m={0} p={0}>
                   <Button
                     variant='solid'
-                    size='lg'
-                    h='100%'
-                    w='100%'
                     borderLeftRadius='none'
+                    size='lg'
                     onClick={() => {
                       if (currentUser?.wethBalance) {
                         setFieldValue(

--- a/src/components/storyHelper.tsx
+++ b/src/components/storyHelper.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { setTestUseCurrentUser } from '../contexts/currentUserContext';
+import { Story } from '@storybook/react';
+
+const mockGetter = () => {
+  return {
+    currentUser: {
+      type: 'web3',
+      attributes: { 'custom:account_address': '111' },
+      network: { chain: 'demoETH' },
+      username: '0x1234567',
+      ethBalance: 1.1,
+      wethBalance: 2.2,
+    },
+    setCurrentUser: () => {},
+  };
+};
+
+export const loggedOutDecorator = (StoryInst: Story) => {
+  setTestUseCurrentUser(mockGetter, true);
+  return <StoryInst />;
+};
+
+export const loggedInDecorator = (StoryInst: Story) => {
+  setTestUseCurrentUser(mockGetter, false);
+  return <StoryInst />;
+};

--- a/src/contexts/currentUserContext.tsx
+++ b/src/contexts/currentUserContext.tsx
@@ -51,7 +51,24 @@ export const CurrentUserContextProvider: React.FC<CurrentUserProps> = ({
   );
 };
 
-export const useCurrentUser = () => {
+const defaultUseCurrentUser = () => {
   const { currentUser, setCurrentUser } = useContext(CurrentUserContext);
   return { currentUser, setCurrentUser };
+};
+
+let activeUseCurrentUser: Function = defaultUseCurrentUser;
+
+export const useCurrentUser = () => activeUseCurrentUser();
+
+export const setTestUseCurrentUser = (
+  testUseCurrentUser: Function,
+  reset: Boolean = false,
+) => {
+  if (reset) {
+    console.log('default userCurrent'); //eslint-disable-line
+    activeUseCurrentUser = defaultUseCurrentUser;
+  } else {
+    console.log('test userCurrent'); //eslint-disable-line
+    activeUseCurrentUser = testUseCurrentUser;
+  }
 };

--- a/src/contexts/currentUserContext.tsx
+++ b/src/contexts/currentUserContext.tsx
@@ -65,10 +65,8 @@ export const setTestUseCurrentUser = (
   reset: Boolean = false,
 ) => {
   if (reset) {
-    console.log('default userCurrent'); //eslint-disable-line
     activeUseCurrentUser = defaultUseCurrentUser;
   } else {
-    console.log('test userCurrent'); //eslint-disable-line
     activeUseCurrentUser = testUseCurrentUser;
   }
 };

--- a/src/theme/components/Button.ts
+++ b/src/theme/components/Button.ts
@@ -1,0 +1,55 @@
+export const Button = {
+  defaultProps: {
+    colorScheme: 'primaryAlpha',
+    variant: 'solid',
+    fontWeight: '400',
+  },
+  variants: {
+    solid: () => ({
+      textTransform: 'uppercase',
+      maxWidth: '100%',
+      width: 'auto',
+      height: '40px',
+      color: 'white',
+      borderRadius: '2px',
+      background:
+        'linear-gradient(94.89deg, #FF5A00 0%, #D62789 70.2%, #AD17AD 100%)',
+      paddingLeft: '24px',
+      paddingRight: '24px',
+      _hover: {
+        background:
+          'linear-gradient(94.89deg, #f78040 0%, #dd459b 70.2%, #ad3bad 100%)',
+      },
+      _focus: {
+        boxShadow: 'none',
+      },
+    }),
+    outline: () => ({
+      textTransform: 'uppercase',
+      maxWidth: '100%',
+      width: 'auto',
+      height: '40px',
+      border: '2px solid',
+      borderRadius: '3px',
+      borderImageSlice: 1,
+      borderImageSource:
+        'linear-gradient(95.58deg, #FF3864 0%, #8B1DBA 53.65%, #4353DF 100%)',
+      background:
+        'linear-gradient(96.18deg, #FF3864 -44.29%, #8B1DBA 53.18%, #4353DF 150.65%);',
+      color: { base: '#8B1DBA', md: 'transparent' }, // added a media query to display RG red on mobile
+      backgroundClip: 'text',
+      paddingLeft: '24px',
+      paddingRight: '24px',
+      transistion: 'all .8s ease-out',
+      _hover: {
+        background:
+          'linear-gradient(96.18deg, #e26f88 0%, #a15ebe 53.65%, #6c77db 100%)',
+        backgroundClip: 'text',
+        color: { base: 'red', md: 'transparent' }, // added a media query to display RG red on mobile
+      },
+      _focus: {
+        boxShadow: 'none',
+      },
+    }),
+  },
+};

--- a/src/theme/components/Form.ts
+++ b/src/theme/components/Form.ts
@@ -1,0 +1,8 @@
+export const Form = {
+  defaultProps: {
+    width: '90%',
+    textAlign: 'left',
+    paddingTop: '2em',
+    paddingBottom: '2em',
+  },
+};

--- a/src/theme/components/Heading.ts
+++ b/src/theme/components/Heading.ts
@@ -1,0 +1,29 @@
+export const Heading = {
+  baseStyle: {},
+  sizes: {},
+  variants: {
+    headingOne: {
+      fontFamily: 'heading',
+      letterSpacing: '1.2px',
+      textShadow: '0 0 0.125em hsl(0 0% 100% / 0.3), 0 0 0.20em red',
+      color: 'white',
+    },
+    headingTwo: {
+      fontFamily: 'heading',
+      letterSpacing: '1.2px',
+      textShadow: '0 0 0.125em hsl(0 0% 100% / 0.3), 0 0 0.20em red',
+      color: 'white',
+    },
+    headingThree: {
+      fontFamily: 'heading',
+      letterSpacing: '1.2px',
+      color: 'red',
+    },
+    labels: {
+      fontFamily: 'label',
+      letterSpacing: '2px',
+      color: 'white',
+    },
+  },
+  defaultProps: {},
+};

--- a/src/theme/components/Input.ts
+++ b/src/theme/components/Input.ts
@@ -1,0 +1,17 @@
+export const Input = {
+  defaultProps: {
+    variant: 'rg',
+  },
+  parts: ['field'],
+  variants: {
+    rg: {
+      field: {
+        color: 'white',
+        bg: 'black',
+        border: '1px solid',
+        borderColor: 'primaryAlpha.500',
+        margin: '5px',
+      },
+    },
+  },
+};

--- a/src/theme/components/Modal.ts
+++ b/src/theme/components/Modal.ts
@@ -1,0 +1,11 @@
+export const Modal = {
+  parts: ['dialog'],
+  baseStyle: {
+    dialog: {
+      bg: 'black',
+      color: 'primary.500',
+      border: '1px solid',
+      borderColor: 'primary.800',
+    },
+  },
+};

--- a/src/theme/components/Text.ts
+++ b/src/theme/components/Text.ts
@@ -1,0 +1,13 @@
+export const Text = {
+  defaultProps: {
+    variant: 'rg',
+  },
+  variants: {
+    rg: {
+      color: 'white',
+      bg: 'black',
+      margin: '5px',
+      textTransform: 'uppercase',
+    },
+  },
+};

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,9 +1,25 @@
 import '@fontsource/mirza';
 import '@fontsource/uncial-antiqua';
 import { extendTheme } from '@chakra-ui/react';
+import { Button } from './components/Button';
+import { Form } from './components/Form';
+import { Input } from './components/Input';
+import { Modal } from './components/Modal';
+import { Text } from './components/Text';
 
 export const theme = extendTheme({
   colors: {
+    transparent: 'transparent',
+    blackDark: 'rgba(10, 10, 10, 0.960784)',
+    blackLight: '#2b2c34',
+    blackLighter: '#16161a',
+    greyLight: '#a7a9be',
+    greyDark: '#4a4a4a',
+    white: '#fffffe',
+    purple: '#822EA6',
+    purpleLight: '#B66AD6',
+    yellow: '#F2E857',
+    yellowDark: '#DCCF11',
     primaryAlpha: {
       // Base colour is at 500
       200: '#ff95ad',
@@ -17,9 +33,11 @@ export const theme = extendTheme({
   },
 
   fonts: {
-    heading: 'Uncial Antiqua',
-    body: 'Mirza',
-    mono: 'Inconsolata',
+    texturina: `'Texturina', serif`,
+    jetbrains: `'JetBrains Mono', monospace`,
+    rubik: `'Rubik Mono One', sans-serif`,
+    uncial: `'Uncial Antiqua', cursive`,
+    spaceMono: `'Space Mono', monospace;`,
   },
 
   styles: {
@@ -38,73 +56,10 @@ export const theme = extendTheme({
   },
 
   components: {
-    Button: {
-      defaultProps: {
-        colorScheme: 'primaryAlpha',
-        variant: 'solid',
-        fontWeight: '400',
-      },
-      variants: {
-        solid: () => ({
-          textTransform: 'uppercase',
-        }),
-        outline: () => ({
-          textTransform: 'uppercase',
-        }),
-      },
-    },
-
-    Form: {
-      defaultProps: {
-        width: '90%',
-        textAlign: 'left',
-        paddingTop: '2em',
-        paddingBottom: '2em',
-      },
-    },
-
-    Input: {
-      defaultProps: {
-        variant: 'rg',
-      },
-      parts: ['field'],
-      variants: {
-        rg: {
-          field: {
-            color: 'white',
-            bg: 'black',
-            border: '1px solid',
-            borderColor: 'primaryAlpha.500',
-            margin: '5px',
-          },
-        },
-      },
-    },
-
-    Text: {
-      defaultProps: {
-        variant: 'rg',
-      },
-      variants: {
-        rg: {
-          color: 'white',
-          bg: 'black',
-          margin: '5px',
-          textTransform: 'uppercase',
-        },
-      },
-    },
-
-    Modal: {
-      parts: ['dialog'],
-      baseStyle: {
-        dialog: {
-          bg: 'black',
-          color: 'primary.500',
-          border: '1px solid',
-          borderColor: 'primary.800',
-        },
-      },
-    },
+    Button,
+    Form,
+    Input,
+    Text,
+    Modal,
   },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3415,6 +3415,56 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
+"@storybook/addon-docs@^6.2.9":
+  version "6.3.7"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-docs/-/addon-docs-6.3.7.tgz#a7b8ff2c0baf85fc9cc1b3d71f481ec40499f3cc"
+  integrity sha512-cyuyoLuB5ELhbrXgnZneDCHqNq1wSdWZ4dzdHy1E5WwLPEhLlD6INfEsm8gnDIb4IncYuzMhK3XYBDd7d3ijOg==
+  dependencies:
+    "@babel/core" "^7.12.10"
+    "@babel/generator" "^7.12.11"
+    "@babel/parser" "^7.12.11"
+    "@babel/plugin-transform-react-jsx" "^7.12.12"
+    "@babel/preset-env" "^7.12.11"
+    "@jest/transform" "^26.6.2"
+    "@mdx-js/loader" "^1.6.22"
+    "@mdx-js/mdx" "^1.6.22"
+    "@mdx-js/react" "^1.6.22"
+    "@storybook/addons" "6.3.7"
+    "@storybook/api" "6.3.7"
+    "@storybook/builder-webpack4" "6.3.7"
+    "@storybook/client-api" "6.3.7"
+    "@storybook/client-logger" "6.3.7"
+    "@storybook/components" "6.3.7"
+    "@storybook/core" "6.3.7"
+    "@storybook/core-events" "6.3.7"
+    "@storybook/csf" "0.0.1"
+    "@storybook/csf-tools" "6.3.7"
+    "@storybook/node-logger" "6.3.7"
+    "@storybook/postinstall" "6.3.7"
+    "@storybook/source-loader" "6.3.7"
+    "@storybook/theming" "6.3.7"
+    acorn "^7.4.1"
+    acorn-jsx "^5.3.1"
+    acorn-walk "^7.2.0"
+    core-js "^3.8.2"
+    doctrine "^3.0.0"
+    escodegen "^2.0.0"
+    fast-deep-equal "^3.1.3"
+    global "^4.4.0"
+    html-tags "^3.1.0"
+    js-string-escape "^1.0.1"
+    loader-utils "^2.0.0"
+    lodash "^4.17.20"
+    p-limit "^3.1.0"
+    prettier "~2.2.1"
+    prop-types "^15.7.2"
+    react-element-to-jsx-string "^14.3.2"
+    regenerator-runtime "^0.13.7"
+    remark-external-links "^8.0.0"
+    remark-slug "^6.0.0"
+    ts-dedent "^2.0.0"
+    util-deprecate "^1.0.2"
+
 "@storybook/addon-essentials@^6.2.9":
   version "6.3.4"
   resolved "https://registry.yarnpkg.com/@storybook/addon-essentials/-/addon-essentials-6.3.4.tgz#2456c81c939b64918f16d851fd5e52234efa94c5"
@@ -3503,6 +3553,21 @@
     global "^4.4.0"
     regenerator-runtime "^0.13.7"
 
+"@storybook/addons@6.3.7":
+  version "6.3.7"
+  resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-6.3.7.tgz#7c6b8d11b65f67b1884f6140437fe996dc39537a"
+  integrity sha512-9stVjTcc52bqqh7YQex/LpSjJ4e2Czm4/ZYDjIiNy0p4OZEx+yLhL5mZzMWh2NQd6vv+pHASBSxf2IeaR5511A==
+  dependencies:
+    "@storybook/api" "6.3.7"
+    "@storybook/channels" "6.3.7"
+    "@storybook/client-logger" "6.3.7"
+    "@storybook/core-events" "6.3.7"
+    "@storybook/router" "6.3.7"
+    "@storybook/theming" "6.3.7"
+    core-js "^3.8.2"
+    global "^4.4.0"
+    regenerator-runtime "^0.13.7"
+
 "@storybook/api@6.3.4", "@storybook/api@^6.3.0":
   version "6.3.4"
   resolved "https://registry.yarnpkg.com/@storybook/api/-/api-6.3.4.tgz#25b8b842104693000b018b3f64986e95fa032b45"
@@ -3516,6 +3581,32 @@
     "@storybook/router" "6.3.4"
     "@storybook/semver" "^7.3.2"
     "@storybook/theming" "6.3.4"
+    "@types/reach__router" "^1.3.7"
+    core-js "^3.8.2"
+    fast-deep-equal "^3.1.3"
+    global "^4.4.0"
+    lodash "^4.17.20"
+    memoizerific "^1.11.3"
+    qs "^6.10.0"
+    regenerator-runtime "^0.13.7"
+    store2 "^2.12.0"
+    telejson "^5.3.2"
+    ts-dedent "^2.0.0"
+    util-deprecate "^1.0.2"
+
+"@storybook/api@6.3.7":
+  version "6.3.7"
+  resolved "https://registry.yarnpkg.com/@storybook/api/-/api-6.3.7.tgz#88b8a51422cd0739c91bde0b1d65fb6d8a8485d0"
+  integrity sha512-57al8mxmE9agXZGo8syRQ8UhvGnDC9zkuwkBPXchESYYVkm3Mc54RTvdAOYDiy85VS4JxiGOywHayCaRwgUddQ==
+  dependencies:
+    "@reach/router" "^1.3.4"
+    "@storybook/channels" "6.3.7"
+    "@storybook/client-logger" "6.3.7"
+    "@storybook/core-events" "6.3.7"
+    "@storybook/csf" "0.0.1"
+    "@storybook/router" "6.3.7"
+    "@storybook/semver" "^7.3.2"
+    "@storybook/theming" "6.3.7"
     "@types/reach__router" "^1.3.7"
     core-js "^3.8.2"
     fast-deep-equal "^3.1.3"
@@ -3605,6 +3696,82 @@
     webpack-hot-middleware "^2.25.0"
     webpack-virtual-modules "^0.2.2"
 
+"@storybook/builder-webpack4@6.3.7":
+  version "6.3.7"
+  resolved "https://registry.yarnpkg.com/@storybook/builder-webpack4/-/builder-webpack4-6.3.7.tgz#1cc1a1184043be3f6ef840d0b43ba91a803105e2"
+  integrity sha512-M5envblMzAUrNqP1+ouKiL8iSIW/90+kBRU2QeWlZoZl1ib+fiFoKk06cgbaC70Bx1lU8nOnI/VBvB5pLhXLaw==
+  dependencies:
+    "@babel/core" "^7.12.10"
+    "@babel/plugin-proposal-class-properties" "^7.12.1"
+    "@babel/plugin-proposal-decorators" "^7.12.12"
+    "@babel/plugin-proposal-export-default-from" "^7.12.1"
+    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.12.1"
+    "@babel/plugin-proposal-object-rest-spread" "^7.12.1"
+    "@babel/plugin-proposal-optional-chaining" "^7.12.7"
+    "@babel/plugin-proposal-private-methods" "^7.12.1"
+    "@babel/plugin-syntax-dynamic-import" "^7.8.3"
+    "@babel/plugin-transform-arrow-functions" "^7.12.1"
+    "@babel/plugin-transform-block-scoping" "^7.12.12"
+    "@babel/plugin-transform-classes" "^7.12.1"
+    "@babel/plugin-transform-destructuring" "^7.12.1"
+    "@babel/plugin-transform-for-of" "^7.12.1"
+    "@babel/plugin-transform-parameters" "^7.12.1"
+    "@babel/plugin-transform-shorthand-properties" "^7.12.1"
+    "@babel/plugin-transform-spread" "^7.12.1"
+    "@babel/plugin-transform-template-literals" "^7.12.1"
+    "@babel/preset-env" "^7.12.11"
+    "@babel/preset-react" "^7.12.10"
+    "@babel/preset-typescript" "^7.12.7"
+    "@storybook/addons" "6.3.7"
+    "@storybook/api" "6.3.7"
+    "@storybook/channel-postmessage" "6.3.7"
+    "@storybook/channels" "6.3.7"
+    "@storybook/client-api" "6.3.7"
+    "@storybook/client-logger" "6.3.7"
+    "@storybook/components" "6.3.7"
+    "@storybook/core-common" "6.3.7"
+    "@storybook/core-events" "6.3.7"
+    "@storybook/node-logger" "6.3.7"
+    "@storybook/router" "6.3.7"
+    "@storybook/semver" "^7.3.2"
+    "@storybook/theming" "6.3.7"
+    "@storybook/ui" "6.3.7"
+    "@types/node" "^14.0.10"
+    "@types/webpack" "^4.41.26"
+    autoprefixer "^9.8.6"
+    babel-loader "^8.2.2"
+    babel-plugin-macros "^2.8.0"
+    babel-plugin-polyfill-corejs3 "^0.1.0"
+    case-sensitive-paths-webpack-plugin "^2.3.0"
+    core-js "^3.8.2"
+    css-loader "^3.6.0"
+    dotenv-webpack "^1.8.0"
+    file-loader "^6.2.0"
+    find-up "^5.0.0"
+    fork-ts-checker-webpack-plugin "^4.1.6"
+    fs-extra "^9.0.1"
+    glob "^7.1.6"
+    glob-promise "^3.4.0"
+    global "^4.4.0"
+    html-webpack-plugin "^4.0.0"
+    pnp-webpack-plugin "1.6.4"
+    postcss "^7.0.36"
+    postcss-flexbugs-fixes "^4.2.1"
+    postcss-loader "^4.2.0"
+    raw-loader "^4.0.2"
+    react-dev-utils "^11.0.3"
+    stable "^0.1.8"
+    style-loader "^1.3.0"
+    terser-webpack-plugin "^4.2.3"
+    ts-dedent "^2.0.0"
+    url-loader "^4.1.1"
+    util-deprecate "^1.0.2"
+    webpack "4"
+    webpack-dev-middleware "^3.7.3"
+    webpack-filter-warnings-plugin "^1.2.1"
+    webpack-hot-middleware "^2.25.0"
+    webpack-virtual-modules "^0.2.2"
+
 "@storybook/channel-postmessage@6.3.4":
   version "6.3.4"
   resolved "https://registry.yarnpkg.com/@storybook/channel-postmessage/-/channel-postmessage-6.3.4.tgz#1a0000aefc9494d5585a1d2c7bdb75f540965f70"
@@ -3618,10 +3785,32 @@
     qs "^6.10.0"
     telejson "^5.3.2"
 
+"@storybook/channel-postmessage@6.3.7":
+  version "6.3.7"
+  resolved "https://registry.yarnpkg.com/@storybook/channel-postmessage/-/channel-postmessage-6.3.7.tgz#bd4edf84a29aa2cd4a22d26115c60194d289a840"
+  integrity sha512-Cmw8HRkeSF1yUFLfEIUIkUICyCXX8x5Ol/5QPbiW9HPE2hbZtYROCcg4bmWqdq59N0Tp9FQNSn+9ZygPgqQtNw==
+  dependencies:
+    "@storybook/channels" "6.3.7"
+    "@storybook/client-logger" "6.3.7"
+    "@storybook/core-events" "6.3.7"
+    core-js "^3.8.2"
+    global "^4.4.0"
+    qs "^6.10.0"
+    telejson "^5.3.2"
+
 "@storybook/channels@6.3.4":
   version "6.3.4"
   resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-6.3.4.tgz#425b31a67e42ac66ccb03465e4ba2e2ef9c8344b"
   integrity sha512-zdZzBbIu9JHEe+uw8FqKsNUiFY+iqI9QdHH/pM3DTTQpBN/JM1Xwfo3CkqA8c5PkhSGqpW0YjXoPash4lawr1Q==
+  dependencies:
+    core-js "^3.8.2"
+    ts-dedent "^2.0.0"
+    util-deprecate "^1.0.2"
+
+"@storybook/channels@6.3.7":
+  version "6.3.7"
+  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-6.3.7.tgz#85ed5925522b802d959810f78d37aacde7fea66e"
+  integrity sha512-aErXO+SRO8MPp2wOkT2n9d0fby+8yM35tq1tI633B4eQsM74EykbXPv7EamrYPqp1AI4BdiloyEpr0hmr2zlvg==
   dependencies:
     core-js "^3.8.2"
     ts-dedent "^2.0.0"
@@ -3651,10 +3840,42 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
+"@storybook/client-api@6.3.7":
+  version "6.3.7"
+  resolved "https://registry.yarnpkg.com/@storybook/client-api/-/client-api-6.3.7.tgz#cb1dca05467d777bd09aadbbdd1dd22ca537ce14"
+  integrity sha512-8wOH19cMIwIIYhZy5O5Wl8JT1QOL5kNuamp9GPmg5ff4DtnG+/uUslskRvsnKyjPvl+WbIlZtBVWBiawVdd/yQ==
+  dependencies:
+    "@storybook/addons" "6.3.7"
+    "@storybook/channel-postmessage" "6.3.7"
+    "@storybook/channels" "6.3.7"
+    "@storybook/client-logger" "6.3.7"
+    "@storybook/core-events" "6.3.7"
+    "@storybook/csf" "0.0.1"
+    "@types/qs" "^6.9.5"
+    "@types/webpack-env" "^1.16.0"
+    core-js "^3.8.2"
+    global "^4.4.0"
+    lodash "^4.17.20"
+    memoizerific "^1.11.3"
+    qs "^6.10.0"
+    regenerator-runtime "^0.13.7"
+    stable "^0.1.8"
+    store2 "^2.12.0"
+    ts-dedent "^2.0.0"
+    util-deprecate "^1.0.2"
+
 "@storybook/client-logger@6.3.4":
   version "6.3.4"
   resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-6.3.4.tgz#c7ee70463c48bb3af704165d5456351ebb667fc2"
   integrity sha512-Gu4M5bBHHQznsdoj8uzYymeojwWq+CRNsUUH41BQIND/RJYSX1IYGIj0yNBP449nv2pjHcTGlN8NJDd+PcELCQ==
+  dependencies:
+    core-js "^3.8.2"
+    global "^4.4.0"
+
+"@storybook/client-logger@6.3.7":
+  version "6.3.7"
+  resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-6.3.7.tgz#ff17b7494e7e9e23089b0d5c5364c371c726bdd1"
+  integrity sha512-BQRErHE3nIEuUJN/3S3dO1LzxAknOgrFeZLd4UVcH/fvjtS1F4EkhcbH+jNyUWvcWGv66PZYN0oFPEn/g3Savg==
   dependencies:
     core-js "^3.8.2"
     global "^4.4.0"
@@ -3689,6 +3910,36 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
+"@storybook/components@6.3.7":
+  version "6.3.7"
+  resolved "https://registry.yarnpkg.com/@storybook/components/-/components-6.3.7.tgz#42b1ca6d24e388e02eab82aa9ed3365db2266ecc"
+  integrity sha512-O7LIg9Z18G0AJqXX7Shcj0uHqwXlSA5UkHgaz9A7mqqqJNl6m6FwwTWcxR1acUfYVNkO+czgpqZHNrOF6rky1A==
+  dependencies:
+    "@popperjs/core" "^2.6.0"
+    "@storybook/client-logger" "6.3.7"
+    "@storybook/csf" "0.0.1"
+    "@storybook/theming" "6.3.7"
+    "@types/color-convert" "^2.0.0"
+    "@types/overlayscrollbars" "^1.12.0"
+    "@types/react-syntax-highlighter" "11.0.5"
+    color-convert "^2.0.1"
+    core-js "^3.8.2"
+    fast-deep-equal "^3.1.3"
+    global "^4.4.0"
+    lodash "^4.17.20"
+    markdown-to-jsx "^7.1.3"
+    memoizerific "^1.11.3"
+    overlayscrollbars "^1.13.1"
+    polished "^4.0.5"
+    prop-types "^15.7.2"
+    react-colorful "^5.1.2"
+    react-popper-tooltip "^3.1.1"
+    react-syntax-highlighter "^13.5.3"
+    react-textarea-autosize "^8.3.0"
+    regenerator-runtime "^0.13.7"
+    ts-dedent "^2.0.0"
+    util-deprecate "^1.0.2"
+
 "@storybook/core-client@6.3.4":
   version "6.3.4"
   resolved "https://registry.yarnpkg.com/@storybook/core-client/-/core-client-6.3.4.tgz#ac75ede84f4ce87c7fc3b31a5d7f602fa712f845"
@@ -3701,6 +3952,29 @@
     "@storybook/core-events" "6.3.4"
     "@storybook/csf" "0.0.1"
     "@storybook/ui" "6.3.4"
+    airbnb-js-shims "^2.2.1"
+    ansi-to-html "^0.6.11"
+    core-js "^3.8.2"
+    global "^4.4.0"
+    lodash "^4.17.20"
+    qs "^6.10.0"
+    regenerator-runtime "^0.13.7"
+    ts-dedent "^2.0.0"
+    unfetch "^4.2.0"
+    util-deprecate "^1.0.2"
+
+"@storybook/core-client@6.3.7":
+  version "6.3.7"
+  resolved "https://registry.yarnpkg.com/@storybook/core-client/-/core-client-6.3.7.tgz#cfb75952e0e1d32f2aca92bca2786334ab589c40"
+  integrity sha512-M/4A65yV+Y4lsCQXX4BtQO/i3BcMPrU5FkDG8qJd3dkcx2fUlFvGWqQPkcTZE+MPVvMEGl/AsEZSADzah9+dAg==
+  dependencies:
+    "@storybook/addons" "6.3.7"
+    "@storybook/channel-postmessage" "6.3.7"
+    "@storybook/client-api" "6.3.7"
+    "@storybook/client-logger" "6.3.7"
+    "@storybook/core-events" "6.3.7"
+    "@storybook/csf" "0.0.1"
+    "@storybook/ui" "6.3.7"
     airbnb-js-shims "^2.2.1"
     ansi-to-html "^0.6.11"
     core-js "^3.8.2"
@@ -3766,10 +4040,71 @@
     util-deprecate "^1.0.2"
     webpack "4"
 
+"@storybook/core-common@6.3.7":
+  version "6.3.7"
+  resolved "https://registry.yarnpkg.com/@storybook/core-common/-/core-common-6.3.7.tgz#9eedf3ff16aff870950e3372ab71ef846fa3ac52"
+  integrity sha512-exLoqRPPsAefwyjbsQBLNFrlPCcv69Q/pclqmIm7FqAPR7f3CKP1rqsHY0PnemizTL/+cLX5S7mY90gI6wpNug==
+  dependencies:
+    "@babel/core" "^7.12.10"
+    "@babel/plugin-proposal-class-properties" "^7.12.1"
+    "@babel/plugin-proposal-decorators" "^7.12.12"
+    "@babel/plugin-proposal-export-default-from" "^7.12.1"
+    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.12.1"
+    "@babel/plugin-proposal-object-rest-spread" "^7.12.1"
+    "@babel/plugin-proposal-optional-chaining" "^7.12.7"
+    "@babel/plugin-proposal-private-methods" "^7.12.1"
+    "@babel/plugin-syntax-dynamic-import" "^7.8.3"
+    "@babel/plugin-transform-arrow-functions" "^7.12.1"
+    "@babel/plugin-transform-block-scoping" "^7.12.12"
+    "@babel/plugin-transform-classes" "^7.12.1"
+    "@babel/plugin-transform-destructuring" "^7.12.1"
+    "@babel/plugin-transform-for-of" "^7.12.1"
+    "@babel/plugin-transform-parameters" "^7.12.1"
+    "@babel/plugin-transform-shorthand-properties" "^7.12.1"
+    "@babel/plugin-transform-spread" "^7.12.1"
+    "@babel/preset-env" "^7.12.11"
+    "@babel/preset-react" "^7.12.10"
+    "@babel/preset-typescript" "^7.12.7"
+    "@babel/register" "^7.12.1"
+    "@storybook/node-logger" "6.3.7"
+    "@storybook/semver" "^7.3.2"
+    "@types/glob-base" "^0.3.0"
+    "@types/micromatch" "^4.0.1"
+    "@types/node" "^14.0.10"
+    "@types/pretty-hrtime" "^1.0.0"
+    babel-loader "^8.2.2"
+    babel-plugin-macros "^3.0.1"
+    babel-plugin-polyfill-corejs3 "^0.1.0"
+    chalk "^4.1.0"
+    core-js "^3.8.2"
+    express "^4.17.1"
+    file-system-cache "^1.0.5"
+    find-up "^5.0.0"
+    fork-ts-checker-webpack-plugin "^6.0.4"
+    glob "^7.1.6"
+    glob-base "^0.3.0"
+    interpret "^2.2.0"
+    json5 "^2.1.3"
+    lazy-universal-dotenv "^3.0.1"
+    micromatch "^4.0.2"
+    pkg-dir "^5.0.0"
+    pretty-hrtime "^1.0.3"
+    resolve-from "^5.0.0"
+    ts-dedent "^2.0.0"
+    util-deprecate "^1.0.2"
+    webpack "4"
+
 "@storybook/core-events@6.3.4", "@storybook/core-events@^6.3.0":
   version "6.3.4"
   resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-6.3.4.tgz#f841b8659a8729d334acd9a6dcfc470c88a2be8f"
   integrity sha512-6qI5bU5VcAoRfxkvpdRqO16eYrX5M0P2E3TakqUUDcgDo5Rfcwd1wTTcwiXslMIh7oiVGiisA+msKTlfzyKf9Q==
+  dependencies:
+    core-js "^3.8.2"
+
+"@storybook/core-events@6.3.7":
+  version "6.3.7"
+  resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-6.3.7.tgz#c5bc7cae7dc295de73b6b9f671ecbe582582e9bd"
+  integrity sha512-l5Hlhe+C/dqxjobemZ6DWBhTOhQoFF3F1Y4kjFGE7pGZl/mas4M72I5I/FUcYCmbk2fbLfZX8hzKkUqS1hdyLA==
   dependencies:
     core-js "^3.8.2"
 
@@ -3812,6 +4147,45 @@
     util-deprecate "^1.0.2"
     webpack "4"
 
+"@storybook/core-server@6.3.7":
+  version "6.3.7"
+  resolved "https://registry.yarnpkg.com/@storybook/core-server/-/core-server-6.3.7.tgz#6f29ad720aafe4a97247b5e306eac4174d0931f2"
+  integrity sha512-m5OPD/rmZA7KFewkXzXD46/i1ngUoFO4LWOiAY/wR6RQGjYXGMhSa5UYFF6MNwSbiGS5YieHkR5crB1HP47AhQ==
+  dependencies:
+    "@storybook/builder-webpack4" "6.3.7"
+    "@storybook/core-client" "6.3.7"
+    "@storybook/core-common" "6.3.7"
+    "@storybook/csf-tools" "6.3.7"
+    "@storybook/manager-webpack4" "6.3.7"
+    "@storybook/node-logger" "6.3.7"
+    "@storybook/semver" "^7.3.2"
+    "@types/node" "^14.0.10"
+    "@types/node-fetch" "^2.5.7"
+    "@types/pretty-hrtime" "^1.0.0"
+    "@types/webpack" "^4.41.26"
+    better-opn "^2.1.1"
+    boxen "^4.2.0"
+    chalk "^4.1.0"
+    cli-table3 "0.6.0"
+    commander "^6.2.1"
+    compression "^1.7.4"
+    core-js "^3.8.2"
+    cpy "^8.1.1"
+    detect-port "^1.3.0"
+    express "^4.17.1"
+    file-system-cache "^1.0.5"
+    fs-extra "^9.0.1"
+    globby "^11.0.2"
+    ip "^1.1.5"
+    node-fetch "^2.6.1"
+    pretty-hrtime "^1.0.3"
+    prompts "^2.4.0"
+    regenerator-runtime "^0.13.7"
+    serve-favicon "^2.5.0"
+    ts-dedent "^2.0.0"
+    util-deprecate "^1.0.2"
+    webpack "4"
+
 "@storybook/core@6.3.4":
   version "6.3.4"
   resolved "https://registry.yarnpkg.com/@storybook/core/-/core-6.3.4.tgz#340c8201180004a067f9ac90f0451cdd4f98b6ad"
@@ -3820,10 +4194,38 @@
     "@storybook/core-client" "6.3.4"
     "@storybook/core-server" "6.3.4"
 
+"@storybook/core@6.3.7":
+  version "6.3.7"
+  resolved "https://registry.yarnpkg.com/@storybook/core/-/core-6.3.7.tgz#482228a270abc3e23fed10c7bc4df674da22ca19"
+  integrity sha512-YTVLPXqgyBg7TALNxQ+cd+GtCm/NFjxr/qQ1mss1T9GCMR0IjE0d0trgOVHHLAO8jCVlK8DeuqZCCgZFTXulRw==
+  dependencies:
+    "@storybook/core-client" "6.3.7"
+    "@storybook/core-server" "6.3.7"
+
 "@storybook/csf-tools@6.3.4":
   version "6.3.4"
   resolved "https://registry.yarnpkg.com/@storybook/csf-tools/-/csf-tools-6.3.4.tgz#5c5df4fcb2bbb71cd6c04b2936ff2d6501562c24"
   integrity sha512-q7+owEWlQa7e/YOt8HXqOvNbtk28YqFOt5/RliXr8s6w7KY7PAlXWckdSBThVSHQnpbk6Fzb0RPqNjxM+qEXiw==
+  dependencies:
+    "@babel/generator" "^7.12.11"
+    "@babel/parser" "^7.12.11"
+    "@babel/plugin-transform-react-jsx" "^7.12.12"
+    "@babel/preset-env" "^7.12.11"
+    "@babel/traverse" "^7.12.11"
+    "@babel/types" "^7.12.11"
+    "@mdx-js/mdx" "^1.6.22"
+    "@storybook/csf" "^0.0.1"
+    core-js "^3.8.2"
+    fs-extra "^9.0.1"
+    js-string-escape "^1.0.1"
+    lodash "^4.17.20"
+    prettier "~2.2.1"
+    regenerator-runtime "^0.13.7"
+
+"@storybook/csf-tools@6.3.7":
+  version "6.3.7"
+  resolved "https://registry.yarnpkg.com/@storybook/csf-tools/-/csf-tools-6.3.7.tgz#505514d211f8698c47ddb15662442098b4b00156"
+  integrity sha512-A7yGsrYwh+vwVpmG8dHpEimX021RbZd9VzoREcILH56u8atssdh/rseljyWlRes3Sr4QgtLvDB7ggoJ+XDZH7w==
   dependencies:
     "@babel/generator" "^7.12.11"
     "@babel/parser" "^7.12.11"
@@ -3890,6 +4292,49 @@
     webpack-dev-middleware "^3.7.3"
     webpack-virtual-modules "^0.2.2"
 
+"@storybook/manager-webpack4@6.3.7":
+  version "6.3.7"
+  resolved "https://registry.yarnpkg.com/@storybook/manager-webpack4/-/manager-webpack4-6.3.7.tgz#9ca604dea38d3c47eb38bf485ca6107861280aa8"
+  integrity sha512-cwUdO3oklEtx6y+ZOl2zHvflICK85emiXBQGgRcCsnwWQRBZOMh+tCgOSZj4jmISVpT52RtT9woG4jKe15KBig==
+  dependencies:
+    "@babel/core" "^7.12.10"
+    "@babel/plugin-transform-template-literals" "^7.12.1"
+    "@babel/preset-react" "^7.12.10"
+    "@storybook/addons" "6.3.7"
+    "@storybook/core-client" "6.3.7"
+    "@storybook/core-common" "6.3.7"
+    "@storybook/node-logger" "6.3.7"
+    "@storybook/theming" "6.3.7"
+    "@storybook/ui" "6.3.7"
+    "@types/node" "^14.0.10"
+    "@types/webpack" "^4.41.26"
+    babel-loader "^8.2.2"
+    case-sensitive-paths-webpack-plugin "^2.3.0"
+    chalk "^4.1.0"
+    core-js "^3.8.2"
+    css-loader "^3.6.0"
+    dotenv-webpack "^1.8.0"
+    express "^4.17.1"
+    file-loader "^6.2.0"
+    file-system-cache "^1.0.5"
+    find-up "^5.0.0"
+    fs-extra "^9.0.1"
+    html-webpack-plugin "^4.0.0"
+    node-fetch "^2.6.1"
+    pnp-webpack-plugin "1.6.4"
+    read-pkg-up "^7.0.1"
+    regenerator-runtime "^0.13.7"
+    resolve-from "^5.0.0"
+    style-loader "^1.3.0"
+    telejson "^5.3.2"
+    terser-webpack-plugin "^4.2.3"
+    ts-dedent "^2.0.0"
+    url-loader "^4.1.1"
+    util-deprecate "^1.0.2"
+    webpack "4"
+    webpack-dev-middleware "^3.7.3"
+    webpack-virtual-modules "^0.2.2"
+
 "@storybook/node-logger@6.3.4", "@storybook/node-logger@^6.2.9":
   version "6.3.4"
   resolved "https://registry.yarnpkg.com/@storybook/node-logger/-/node-logger-6.3.4.tgz#ab7bd9f78f9ff10c9d20439734de6882233a9a75"
@@ -3901,10 +4346,28 @@
     npmlog "^4.1.2"
     pretty-hrtime "^1.0.3"
 
+"@storybook/node-logger@6.3.7":
+  version "6.3.7"
+  resolved "https://registry.yarnpkg.com/@storybook/node-logger/-/node-logger-6.3.7.tgz#492469ea4749de8d984af144976961589a1ac382"
+  integrity sha512-YXHCblruRe6HcNefDOpuXJoaybHnnSryIVP9Z+gDv6OgLAMkyxccTIaQL9dbc/eI4ywgzAz4kD8t1RfVwXNVXw==
+  dependencies:
+    "@types/npmlog" "^4.1.2"
+    chalk "^4.1.0"
+    core-js "^3.8.2"
+    npmlog "^4.1.2"
+    pretty-hrtime "^1.0.3"
+
 "@storybook/postinstall@6.3.4":
   version "6.3.4"
   resolved "https://registry.yarnpkg.com/@storybook/postinstall/-/postinstall-6.3.4.tgz#134981ce120715b5914c04e91e162adc086c92ca"
   integrity sha512-HGqpChxBiDH7iQ1KDKr1sWoSdwPrVYPAuhvxAPaQhmL159cGyrcJ1PSit9iQt2NMkm+hIfuTcBQOu6eiZw3iYg==
+  dependencies:
+    core-js "^3.8.2"
+
+"@storybook/postinstall@6.3.7":
+  version "6.3.7"
+  resolved "https://registry.yarnpkg.com/@storybook/postinstall/-/postinstall-6.3.7.tgz#7d90c06131382a3cf1550a1f2c70df13b220d9d3"
+  integrity sha512-HgTj7WdWo2cXrGfEhi5XYZA+G4vIzECtJHK22GEL9QxJth60Ah/dE94VqpTlyhSpzP74ZFUgr92+pP9o+j3CCw==
   dependencies:
     core-js "^3.8.2"
 
@@ -3979,6 +4442,22 @@
     qs "^6.10.0"
     ts-dedent "^2.0.0"
 
+"@storybook/router@6.3.7":
+  version "6.3.7"
+  resolved "https://registry.yarnpkg.com/@storybook/router/-/router-6.3.7.tgz#1714a99a58a7b9f08b6fcfe2b678dad6ca896736"
+  integrity sha512-6tthN8op7H0NoYoE1SkQFJKC42pC4tGaoPn7kEql8XGeUJnxPtVFjrnywlTrRnKuxZKIvbilQBAwDml97XH23Q==
+  dependencies:
+    "@reach/router" "^1.3.4"
+    "@storybook/client-logger" "6.3.7"
+    "@types/reach__router" "^1.3.7"
+    core-js "^3.8.2"
+    fast-deep-equal "^3.1.3"
+    global "^4.4.0"
+    lodash "^4.17.20"
+    memoizerific "^1.11.3"
+    qs "^6.10.0"
+    ts-dedent "^2.0.0"
+
 "@storybook/semver@^7.3.2":
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/@storybook/semver/-/semver-7.3.2.tgz#f3b9c44a1c9a0b933c04e66d0048fcf2fa10dac0"
@@ -3994,6 +4473,22 @@
   dependencies:
     "@storybook/addons" "6.3.4"
     "@storybook/client-logger" "6.3.4"
+    "@storybook/csf" "0.0.1"
+    core-js "^3.8.2"
+    estraverse "^5.2.0"
+    global "^4.4.0"
+    loader-utils "^2.0.0"
+    lodash "^4.17.20"
+    prettier "~2.2.1"
+    regenerator-runtime "^0.13.7"
+
+"@storybook/source-loader@6.3.7":
+  version "6.3.7"
+  resolved "https://registry.yarnpkg.com/@storybook/source-loader/-/source-loader-6.3.7.tgz#cc348305df3c2d8d716c0bab7830c9f537b859ff"
+  integrity sha512-0xQTq90jwx7W7MJn/idEBCGPOyxi/3No5j+5YdfJsSGJRuMFH3jt6pGgdeZ4XA01cmmIX6bZ+fB9al6yAzs91w==
+  dependencies:
+    "@storybook/addons" "6.3.7"
+    "@storybook/client-logger" "6.3.7"
     "@storybook/csf" "0.0.1"
     core-js "^3.8.2"
     estraverse "^5.2.0"
@@ -4021,6 +4516,24 @@
     resolve-from "^5.0.0"
     ts-dedent "^2.0.0"
 
+"@storybook/theming@6.3.7":
+  version "6.3.7"
+  resolved "https://registry.yarnpkg.com/@storybook/theming/-/theming-6.3.7.tgz#6daf9a21b26ed607f3c28a82acd90c0248e76d8b"
+  integrity sha512-GXBdw18JJd5jLLcRonAZWvGGdwEXByxF1IFNDSOYCcpHWsMgTk4XoLjceu9MpXET04pVX51LbVPLCvMdggoohg==
+  dependencies:
+    "@emotion/core" "^10.1.1"
+    "@emotion/is-prop-valid" "^0.8.6"
+    "@emotion/styled" "^10.0.27"
+    "@storybook/client-logger" "6.3.7"
+    core-js "^3.8.2"
+    deep-object-diff "^1.1.0"
+    emotion-theming "^10.0.27"
+    global "^4.4.0"
+    memoizerific "^1.11.3"
+    polished "^4.0.5"
+    resolve-from "^5.0.0"
+    ts-dedent "^2.0.0"
+
 "@storybook/ui@6.3.4":
   version "6.3.4"
   resolved "https://registry.yarnpkg.com/@storybook/ui/-/ui-6.3.4.tgz#348ea6eb2b0d5428ab88221485c531fb761ef27d"
@@ -4036,6 +4549,41 @@
     "@storybook/router" "6.3.4"
     "@storybook/semver" "^7.3.2"
     "@storybook/theming" "6.3.4"
+    "@types/markdown-to-jsx" "^6.11.3"
+    copy-to-clipboard "^3.3.1"
+    core-js "^3.8.2"
+    core-js-pure "^3.8.2"
+    downshift "^6.0.15"
+    emotion-theming "^10.0.27"
+    fuse.js "^3.6.1"
+    global "^4.4.0"
+    lodash "^4.17.20"
+    markdown-to-jsx "^6.11.4"
+    memoizerific "^1.11.3"
+    polished "^4.0.5"
+    qs "^6.10.0"
+    react-draggable "^4.4.3"
+    react-helmet-async "^1.0.7"
+    react-sizeme "^3.0.1"
+    regenerator-runtime "^0.13.7"
+    resolve-from "^5.0.0"
+    store2 "^2.12.0"
+
+"@storybook/ui@6.3.7":
+  version "6.3.7"
+  resolved "https://registry.yarnpkg.com/@storybook/ui/-/ui-6.3.7.tgz#d0caea50640670da3189bbbb67c43da30c90455a"
+  integrity sha512-PBeRO8qtwAbtHvxUgNtz/ChUR6qnN+R37dMaIs3Y96jbks1fS2K9Mt7W5s1HnUbWbg2KsZMv9D4VYPBasY+Isw==
+  dependencies:
+    "@emotion/core" "^10.1.1"
+    "@storybook/addons" "6.3.7"
+    "@storybook/api" "6.3.7"
+    "@storybook/channels" "6.3.7"
+    "@storybook/client-logger" "6.3.7"
+    "@storybook/components" "6.3.7"
+    "@storybook/core-events" "6.3.7"
+    "@storybook/router" "6.3.7"
+    "@storybook/semver" "^7.3.2"
+    "@storybook/theming" "6.3.7"
     "@types/markdown-to-jsx" "^6.11.3"
     copy-to-clipboard "^3.3.1"
     core-js "^3.8.2"
@@ -5154,6 +5702,18 @@
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
 
+"@webpack-contrib/schema-utils@^1.0.0-beta.0":
+  version "1.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@webpack-contrib/schema-utils/-/schema-utils-1.0.0-beta.0.tgz#bf9638c9464d177b48209e84209e23bee2eb4f65"
+  integrity sha512-LonryJP+FxQQHsjGBi6W786TQB1Oym+agTpY0c+Kj8alnIw+DLUJb6SI8Y1GHGhLCH1yPRrucjObUmxNICQ1pg==
+  dependencies:
+    ajv "^6.1.0"
+    ajv-keywords "^3.1.0"
+    chalk "^2.3.2"
+    strip-ansi "^4.0.0"
+    text-table "^0.2.0"
+    webpack-log "^1.1.2"
+
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"
@@ -5559,7 +6119,7 @@ arrify@^2.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-2.0.1.tgz#c9655e9331e0abcd588d2a7cad7e9956f66701fa"
   integrity sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==
 
-asap@~2.0.6:
+asap@~2.0.3, asap@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
@@ -6631,7 +7191,7 @@ ccount@^1.0.0:
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.1.0.tgz#246687debb6014735131be8abab2d93898f8d043"
   integrity sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==
 
-chalk@2.4.2, chalk@^2.0.0, chalk@^2.4.1, chalk@^2.4.2:
+chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.2, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -7195,6 +7755,11 @@ core-js-pure@^3.8.2:
   version "3.15.2"
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.15.2.tgz#c8e0874822705f3385d3197af9348f7c9ae2e3ce"
   integrity sha512-D42L7RYh1J2grW8ttxoY1+17Y4wXZeKe7uyplAI3FkNQyI5OgBIAjUfFiTPfL1rs0qLpxaabITNbjKl1Sp82tA==
+
+core-js@^1.0.0:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
+  integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
 
 core-js@^2.4.0:
   version "2.6.12"
@@ -8243,6 +8808,13 @@ encodeurl@~1.0.2:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
 
+encoding@^0.1.11:
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.13.tgz#56574afdd791f54a8e9b2785c0582a2d26210fa9"
+  integrity sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==
+  dependencies:
+    iconv-lite "^0.6.2"
+
 end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
@@ -8259,7 +8831,7 @@ endent@^2.0.1:
     fast-json-parse "^1.0.3"
     objectorarray "^1.0.5"
 
-enhanced-resolve@^4.3.0, enhanced-resolve@^4.5.0:
+enhanced-resolve@^4.0.0, enhanced-resolve@^4.3.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz#2f3cfd84dbe3b487f18f2db2ef1e064a571ca5ec"
   integrity sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==
@@ -9319,6 +9891,19 @@ fb-watchman@^2.0.0:
   integrity sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==
   dependencies:
     bser "2.1.1"
+
+fbjs@^0.8.4:
+  version "0.8.17"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
+  integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.18"
 
 figgy-pudding@^3.5.1:
   version "3.5.2"
@@ -10551,6 +11136,13 @@ iconv-lite@0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+iconv-lite@^0.6.2:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
+
 icss-utils@^4.0.0, icss-utils@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-4.1.1.tgz#21170b53789ee27447c2f47dd683081403f9a467"
@@ -11161,7 +11753,7 @@ is-set@^2.0.2:
   resolved "https://registry.yarnpkg.com/is-set/-/is-set-2.0.2.tgz#90755fa4c2562dc1c5d4024760d6119b94ca18ec"
   integrity sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==
 
-is-stream@^1.0.0, is-stream@^1.1.0:
+is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
@@ -11272,6 +11864,14 @@ isobject@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-4.0.0.tgz#3f1c9155e73b192022a80819bacd0343711697b0"
   integrity sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==
+
+isomorphic-fetch@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
+  integrity sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=
+  dependencies:
+    node-fetch "^1.0.1"
+    whatwg-fetch ">=0.10.0"
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -12315,10 +12915,25 @@ lodash.uniq@4.5.0, lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
+log-symbols@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
+  integrity sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==
+  dependencies:
+    chalk "^2.0.1"
+
 loglevel@^1.6.8:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.7.1.tgz#005fde2f5e6e47068f935ff28573e125ef72f197"
   integrity sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw==
+
+loglevelnext@^1.0.1:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/loglevelnext/-/loglevelnext-1.0.5.tgz#36fc4f5996d6640f539ff203ba819641680d75a2"
+  integrity sha512-V/73qkPuJmx4BcBF19xPBr+0ZRVBhc4POxvZTZdMeXpJ4NItXSJ/MSwuFT0kQJlCbXvdlZoQQ/418bS1y9Jh6A==
+  dependencies:
+    es6-symbol "^3.1.1"
+    object.assign "^4.1.0"
 
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
@@ -12631,7 +13246,7 @@ micromatch@^3.1.10, micromatch@^3.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
-micromatch@^4.0.2, micromatch@^4.0.4:
+micromatch@^4.0.0, micromatch@^4.0.2, micromatch@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.4.tgz#896d519dfe9db25fce94ceb7a500919bf881ebf9"
   integrity sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==
@@ -12991,6 +13606,11 @@ nested-error-stacks@^2.0.0, nested-error-stacks@^2.1.0:
   resolved "https://registry.yarnpkg.com/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz#0fbdcf3e13fe4994781280524f8b96b0cdff9c61"
   integrity sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==
 
+nested-object-assign@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/nested-object-assign/-/nested-object-assign-1.0.4.tgz#c9db56078eb6043960fdb6ba918a5122a06ccac4"
+  integrity sha512-FlZ7oN9ICt+fbcJ4ag2IsALIcalfE/E16ttdSA8peBiHJI+oEKdOcafqDnUbeUe5NwWGn/m9zZGO9qrAGzfesg==
+
 next-tick@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
@@ -13025,6 +13645,14 @@ node-fetch@2.6.1, node-fetch@^2.6.0, node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
+node-fetch@^1.0.1:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
+  integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
+  dependencies:
+    encoding "^0.1.11"
+    is-stream "^1.0.1"
 
 node-forge@^0.10.0:
   version "0.10.0"
@@ -14751,6 +15379,13 @@ promise.prototype.finally@^3.1.0:
     es-abstract "^1.17.0-next.0"
     function-bind "^1.1.1"
 
+promise@^7.1.1:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
+  integrity sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==
+  dependencies:
+    asap "~2.0.3"
+
 promise@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/promise/-/promise-8.1.0.tgz#697c25c3dfe7435dd79fcd58c38a135888eaf05e"
@@ -15006,6 +15641,15 @@ raw-loader@^4.0.2:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
 
+react-addons-create-fragment@^15.6.2:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/react-addons-create-fragment/-/react-addons-create-fragment-15.6.2.tgz#a394de7c2c7becd6b5475ba1b97ac472ce7c74f8"
+  integrity sha1-o5TefCx77Na1R1uhuXrEcs58dPg=
+  dependencies:
+    fbjs "^0.8.4"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.0"
+
 react-app-polyfill@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/react-app-polyfill/-/react-app-polyfill-2.0.0.tgz#a0bea50f078b8a082970a9d853dc34b6dcc6a3cf"
@@ -15060,6 +15704,15 @@ react-dev-utils@^11.0.3:
     strip-ansi "6.0.0"
     text-table "0.2.0"
 
+react-docgen-typescript-loader@3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/react-docgen-typescript-loader/-/react-docgen-typescript-loader-3.7.2.tgz#45cb2305652c0602767242a8700ad1ebd66bbbbd"
+  integrity sha512-fNzUayyUGzSyoOl7E89VaPKJk9dpvdSgyXg81cUkwy0u+NBvkzQG3FC5WBIlXda0k/iaxS+PWi+OC+tUiGxzPA==
+  dependencies:
+    "@webpack-contrib/schema-utils" "^1.0.0-beta.0"
+    loader-utils "^1.2.3"
+    react-docgen-typescript "^1.15.0"
+
 react-docgen-typescript-plugin@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/react-docgen-typescript-plugin/-/react-docgen-typescript-plugin-1.0.0.tgz#f3b13df1acf3126957c689c47cd8552d42734feb"
@@ -15074,7 +15727,7 @@ react-docgen-typescript-plugin@^1.0.0:
     tslib "^2.0.0"
     webpack-sources "^2.2.0"
 
-react-docgen-typescript@^1.22.0:
+react-docgen-typescript@^1.15.0, react-docgen-typescript@^1.22.0:
   version "1.22.0"
   resolved "https://registry.yarnpkg.com/react-docgen-typescript/-/react-docgen-typescript-1.22.0.tgz#00232c8e8e47f4437cac133b879b3e9437284bee"
   integrity sha512-MPLbF8vzRwAG3GcjdL+OHQlhgtWsLTXs+7uJiHfEeT3Ur7IsZaNYqRTLQ9sj2nB6M6jylcPCeCmH7qbszJmecg==
@@ -16033,7 +16686,7 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
-"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
+"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -16724,6 +17377,22 @@ storybook-addon-outline@^1.4.1:
     "@storybook/components" "^6.3.0"
     "@storybook/core-events" "^6.3.0"
     ts-dedent "^2.1.1"
+
+storybook-addon-react-docgen@1.2.42:
+  version "1.2.42"
+  resolved "https://registry.yarnpkg.com/storybook-addon-react-docgen/-/storybook-addon-react-docgen-1.2.42.tgz#01b3d782612627304ae077c98bf6f5fce3fecb5b"
+  integrity sha512-STQ7HU4+N8zaOHgwNkElABuqsnbXQMVckh6rroTU2pqdP10oQQ+rVfIbLX3wEFg5bbQk1FUzc/DNR0kSJtUASw==
+  dependencies:
+    nested-object-assign "^1.0.3"
+    prop-types "^15.6.2"
+    react-addons-create-fragment "^15.6.2"
+    react-lifecycles-compat "^3.0.4"
+    storybook-pretty-props "^1.2.1"
+
+storybook-pretty-props@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/storybook-pretty-props/-/storybook-pretty-props-1.2.1.tgz#04c6e7c80efc0190a5dd94dceaf50579c159e182"
+  integrity sha512-3dUtu0UbBA6idA3Qo0i+CYGGz8GiqlXzhgCJdT065jnuJ3y9intKxZpv05ZbnQXCPnsPVSDos+hgOZ444hf6xA==
 
 stream-browserify@^2.0.1:
   version "2.0.2"
@@ -17456,6 +18125,17 @@ ts-essentials@^2.0.3:
   resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-2.0.12.tgz#c9303f3d74f75fa7528c3d49b80e089ab09d8745"
   integrity sha512-3IVX4nI6B5cc31/GFFE+i8ey/N2eA0CZDbo6n0yrz0zDX8ZJ8djmU1p+XRz7G3is0F3bB3pu2pAroFdAWQKU3w==
 
+ts-loader@8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-8.2.0.tgz#6a3aeaa378aecda543e2ed2c332d3123841d52e0"
+  integrity sha512-ebXBFrNyMSmbWgjnb3WBloUBK+VSx1xckaXsMXxlZRDqce/OPdYBVN5efB0W3V0defq0Gcy4YuzvPGqRgjj85A==
+  dependencies:
+    chalk "^4.1.0"
+    enhanced-resolve "^4.0.0"
+    loader-utils "^2.0.0"
+    micromatch "^4.0.0"
+    semver "^7.3.4"
+
 ts-pnp@1.2.0, ts-pnp@^1.1.6:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
@@ -17579,10 +18259,15 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.2.4:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.2.tgz#399ab18aac45802d6f2498de5054fcbbe716a805"
-  integrity sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==
+typescript@4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.2.tgz#1450f020618f872db0ea17317d16d8da8ddb8c4c"
+  integrity sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ==
+
+ua-parser-js@^0.7.18:
+  version "0.7.28"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.28.tgz#8ba04e653f35ce210239c64661685bf9121dec31"
+  integrity sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==
 
 ultron@~1.1.0:
   version "1.1.1"
@@ -17958,7 +18643,7 @@ uuid@3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
-uuid@^3.3.2, uuid@^3.4.0:
+uuid@^3.1.0, uuid@^3.3.2, uuid@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
@@ -18462,6 +19147,16 @@ webpack-hot-middleware@^2.25.0:
     querystring "^0.2.0"
     strip-ansi "^3.0.0"
 
+webpack-log@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/webpack-log/-/webpack-log-1.2.0.tgz#a4b34cda6b22b518dbb0ab32e567962d5c72a43d"
+  integrity sha512-U9AnICnu50HXtiqiDxuli5gLB5PGBo7VvcHx36jRZHwK4vzOYLbImqT4lwWwoMHdQWwEKw736fCHEekokTEKHA==
+  dependencies:
+    chalk "^2.1.0"
+    log-symbols "^2.1.0"
+    loglevelnext "^1.0.1"
+    uuid "^3.1.0"
+
 webpack-log@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/webpack-log/-/webpack-log-2.0.0.tgz#5b7928e0637593f119d32f6227c1e0ac31e1b47f"
@@ -18503,36 +19198,7 @@ webpack-virtual-modules@^0.2.2:
   dependencies:
     debug "^3.0.0"
 
-webpack@4:
-  version "4.46.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.46.0.tgz#bf9b4404ea20a073605e0a011d188d77cb6ad542"
-  integrity sha512-6jJuJjg8znb/xRItk7bkT0+Q7AHCYjjFnvKIWQPkNIOyRqoCGvkOs0ipeQzrqz4l5FtN5ZI/ukEHroeX/o1/5Q==
-  dependencies:
-    "@webassemblyjs/ast" "1.9.0"
-    "@webassemblyjs/helper-module-context" "1.9.0"
-    "@webassemblyjs/wasm-edit" "1.9.0"
-    "@webassemblyjs/wasm-parser" "1.9.0"
-    acorn "^6.4.1"
-    ajv "^6.10.2"
-    ajv-keywords "^3.4.1"
-    chrome-trace-event "^1.0.2"
-    enhanced-resolve "^4.5.0"
-    eslint-scope "^4.0.3"
-    json-parse-better-errors "^1.0.2"
-    loader-runner "^2.4.0"
-    loader-utils "^1.2.3"
-    memory-fs "^0.4.1"
-    micromatch "^3.1.10"
-    mkdirp "^0.5.3"
-    neo-async "^2.6.1"
-    node-libs-browser "^2.2.1"
-    schema-utils "^1.0.0"
-    tapable "^1.1.3"
-    terser-webpack-plugin "^1.4.3"
-    watchpack "^1.7.4"
-    webpack-sources "^1.4.1"
-
-webpack@4.44.2:
+webpack@4, webpack@4.44.2:
   version "4.44.2"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.44.2.tgz#6bfe2b0af055c8b2d1e90ed2cd9363f841266b72"
   integrity sha512-6KJVGlCxYdISyurpQ0IPTklv+DULv05rs2hseIXer6D7KrUicRDLFb4IUM1S6LUAKypPM/nSiVSuv8jHu1m3/Q==
@@ -18599,7 +19265,7 @@ whatwg-fetch@2.0.4:
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
   integrity sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==
 
-whatwg-fetch@^3.4.1:
+whatwg-fetch@>=0.10.0, whatwg-fetch@^3.4.1:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
   integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==


### PR DESCRIPTION
This initial PR to enhance the Stories for Wethwrapper adds the ability to mock the current user, so that we can make Storybook show both component views without forcing the user to use Metamask to do that.

Note that Storybook interacts very poorly with React State, and so rather than introduce a whole mocking library (most of which do not work with both libraries), I have made a testing method to allow this user mocking.